### PR TITLE
ACE compat: fixed script error on respawn

### DIFF
--- a/optionals/ace_compat/XEH_respawn.sqf
+++ b/optionals/ace_compat/XEH_respawn.sqf
@@ -4,4 +4,4 @@
 params ["_unit"];
 
 // reset variable
-_unit setVariable [GVAR(cyanide_flag), false];
+_unit setVariable [QGVAR(cyanide_flag), false];


### PR DESCRIPTION
I fixed a script error that was thrown on respawn when using BlackOrder with ACE compat. The error was due to incorrect using of a macro command.